### PR TITLE
Add pysqlite to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sqlalchemy
 fedmsg
 dogpile.cache
 fedmsg_meta_fedora_infrastructure
+pysqlite


### PR DESCRIPTION
It's used by default for the db
